### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Django CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Cadeval/WebApp/security/code-scanning/1](https://github.com/Cadeval/WebApp/security/code-scanning/1)

To address this problem, the best fix is to add a `permissions` block to the workflow. Given its location, two approaches are possible: (a) at the workflow root (affecting all jobs), or (b) scoped to individual jobs. Since the workflow only has one job, adding the block to the root is both simpler and sufficient. The minimal required privilege for operations such as running tests and checking out code is `contents: read`, so add the following at the top level, just below or above the `on:` block. No imports or further definitions are needed—just a one-line `permissions` block. This does not change any existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
